### PR TITLE
Avoid empty options in connection string

### DIFF
--- a/lib/Pg/PQ.pm
+++ b/lib/Pg/PQ.pm
@@ -36,7 +36,7 @@ sub _make_conninfo {
         }
         %opts = @_;
     }
-    push @conninfo, map _escape_opt($_).'='._escape_opt($opts{$_}), keys %opts;
+    push @conninfo, map _escape_opt($_).'='._escape_opt($opts{$_}), grep defined $opts{$_} && $opts{$_} ne '', keys %opts;
     no warnings 'numeric';
     push @conninfo, 'client_encoding=UTF8' if Pg::PQ::libVersion() >= 9;
     # warn "conninfo: >@conninfo<\n";


### PR DESCRIPTION
Empty option values break the conninfo string. 

If you manage to pass, e.g. empty password, conninfo string will be like
   connect_timeout=2 password= user=vasa port=1111 dbname=test host=localhost client_encoding=UTF8
which is incorrect. 'user=vasa' will be considered as the password value.

Therefore,  the empty connection attributes must be skipped.