### PR TITLE
Fix version detection to work with PostgreSQL 10.0

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -6,7 +6,7 @@ use warnings;
 
 use 5.010;
 
-my ($version, $major) = `pg_config --version 2>&1` =~ /PostgreSQL\s+((\d+)\.\d+(?:\.\d+|\w+))\b/i;
+my ($version, $major) = `pg_config --version 2>&1` =~ /PostgreSQL\s+((\d+)\.\d+(?:\.\d+|\w+)?)\b/i;
 unless (defined $major and $major >= 8) {
     die "libpq 8.x.x or later required (" . ($version // 'none') . " found)\n";
 }


### PR DESCRIPTION
Version 10 outputs the line "PostgreSQL 10.0" for `pg_config --version`, which does not match the previous regexp